### PR TITLE
Clean up tests

### DIFF
--- a/KaleidoscopeLang.xcodeproj/project.pbxproj
+++ b/KaleidoscopeLang.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		B88DBAC11BF337A300AC3BB5 /* Assertions.swift in Sources */ = {isa = PBXBuildFile; fileRef = B88DBABF1BF3377600AC3BB5 /* Assertions.swift */; };
 		B8B97E581BEF55CE00CCFC4B /* KaleidoscopeLang.h in Headers */ = {isa = PBXBuildFile; fileRef = B8B97E571BEF55CE00CCFC4B /* KaleidoscopeLang.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		B8B97E5F1BEF55CE00CCFC4B /* KaleidoscopeLang.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B8B97E541BEF55CE00CCFC4B /* KaleidoscopeLang.framework */; };
 		B8B97E641BEF55CE00CCFC4B /* KaleidoscopeLangTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8B97E631BEF55CE00CCFC4B /* KaleidoscopeLangTests.swift */; };
@@ -36,6 +37,7 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		B88DBABF1BF3377600AC3BB5 /* Assertions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Assertions.swift; sourceTree = "<group>"; };
 		B8B97E541BEF55CE00CCFC4B /* KaleidoscopeLang.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = KaleidoscopeLang.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		B8B97E571BEF55CE00CCFC4B /* KaleidoscopeLang.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = KaleidoscopeLang.h; sourceTree = "<group>"; };
 		B8B97E591BEF55CE00CCFC4B /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; name = Info.plist; path = KaleidoscopeLang/Info.plist; sourceTree = "<group>"; };
@@ -117,6 +119,7 @@
 			isa = PBXGroup;
 			children = (
 				B8B97E631BEF55CE00CCFC4B /* KaleidoscopeLangTests.swift */,
+				B88DBABF1BF3377600AC3BB5 /* Assertions.swift */,
 				B8B97E651BEF55CE00CCFC4B /* Info.plist */,
 			);
 			path = KaleidoscopeLangTests;
@@ -256,6 +259,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				B88DBAC11BF337A300AC3BB5 /* Assertions.swift in Sources */,
 				B8B97E641BEF55CE00CCFC4B /* KaleidoscopeLangTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/KaleidoscopeLang/TokenParser.swift
+++ b/KaleidoscopeLang/TokenParser.swift
@@ -10,7 +10,7 @@ import Either
 import Madness
 import Prelude
 
-private typealias TokenParser = Parser<String.CharacterView, Token>.Function
+internal typealias TokenParser = Parser<String.CharacterView, Token>.Function
 internal typealias TokenArrayParser = Parser<String.CharacterView, [Token]>.Function
 
 // Characters
@@ -30,13 +30,13 @@ private let identifierCharacters: CharacterArrayParser = prepend <^> identifierS
 private let identifierString: StringParser = String.init <^> identifierCharacters
 
 // Tokens
-private let identifier: TokenParser = Token.Identifier <^> identifierString
-private let character: TokenParser = Token.Character <^> (op <|> paren)
-private let def: TokenParser = const(.Def) <^> %"def"
-private let extern: TokenParser = const(.Extern) <^> %"extern"
-private let number: TokenParser = Token.Number <^> Madness.number
-private let endOfStatement: TokenParser = const(.EndOfStatement) <^> %";"
-private let token = def <|> extern <|> identifier <|> number <|> character <|> endOfStatement
+internal let identifierToken: TokenParser = Token.Identifier <^> identifierString
+internal let characterToken: TokenParser = Token.Character <^> (op <|> paren)
+internal let defToken: TokenParser = const(.Def) <^> %"def"
+internal let externToken: TokenParser = const(.Extern) <^> %"extern"
+internal let numberToken: TokenParser = Token.Number <^> Madness.number
+internal let endOfStatementToken: TokenParser = const(.EndOfStatement) <^> %";"
+internal let token = defToken <|> externToken <|> identifierToken <|> numberToken <|> characterToken <|> endOfStatementToken
 
 private let tokenRun: TokenArrayParser = many(token <* many(whitespace))
 private let tokenLine: TokenArrayParser = many(whitespace) *> tokenRun <* comment|?

--- a/KaleidoscopeLangTests/Assertions.swift
+++ b/KaleidoscopeLangTests/Assertions.swift
@@ -26,6 +26,25 @@ func assert<T>(left: T?, _ match: (T, T) -> Bool, _ right: T?, message: String =
     }
 }
 
+func assertMatched<C: CollectionType, T>(parser: Parser<C,T>.Function, _ input: C, message: String = "", file: String = __FILE__, line: UInt = __LINE__) {
+    switch parse(parser, input: input) {
+    case .Left(_):
+        XCTFail("should have matched \(input). " + message, file: file, line: line)
+    case .Right(_):
+        break;
+    }
+}
+
+
+func assertUnmatched<C: CollectionType, T>(parser: Parser<C,T>.Function, _ input: C, message: String = "", file: String = __FILE__, line: UInt = __LINE__) {
+    switch parse(parser, input: input) {
+    case .Left(_):
+        break
+    case .Right(_):
+        XCTFail("should not have matched \(input). " + message, file: file, line: line)
+    }
+}
+
 func assertStringToTokens(string: String, _ tokens: [Token], message: String = "", file: String = __FILE__, line: UInt = __LINE__) {
     let parsed = tokenizeTopLevelExpression(string)
     assert(parsed.right, ==, tokens, message: message, file: file, line: line)

--- a/KaleidoscopeLangTests/Assertions.swift
+++ b/KaleidoscopeLangTests/Assertions.swift
@@ -1,0 +1,42 @@
+//
+//  Assertions.swift
+//  KaleidoscopeLang
+//
+//  Created by Ben Cochran on 11/11/15.
+//  Copyright © 2015 Ben Cochran. All rights reserved.
+//
+
+import XCTest
+import Madness
+import Either
+@testable import KaleidoscopeLang
+
+func assert<T>(left: T?, _ match: (T, T) -> Bool, _ right: T?, message: String = "", file: String = __FILE__, line: UInt = __LINE__) {
+    switch (left, right) {
+    case (.None, .None):
+        break;
+    case let (.Some(l), .Some(r)) where match(l, r):
+        break;
+    case let (.Some(l), .Some(r)):
+        XCTFail("\(String(reflecting: l)) did not match \(String(reflecting: r)). " + message, file: file, line: line)
+    case let (.Some(l), .None):
+        XCTFail("\(String(reflecting: l)) did not match nil. " + message, file: file, line: line)
+    case let (.None, .Some(r)):
+        XCTFail("nil did not match \(String(reflecting: r)). " + message, file: file, line: line)
+    }
+}
+
+func assertStringToTokens(string: String, _ tokens: [Token], message: String = "", file: String = __FILE__, line: UInt = __LINE__) {
+    let parsed = tokenizeTopLevelExpression(string)
+    assert(parsed.right, ==, tokens, message: message, file: file, line: line)
+}
+
+func assertTokensToExpression(tokens: [Token], _ expression: Expression, message: String = "", file: String = __FILE__, line: UInt = __LINE__) {
+    let parsed = parse(topLevelExpression, input: tokens)
+    assert(parsed.right, ==, expression, message: message, file: file, line: line)
+}
+
+func assertStringToExpression(string: String, _ expression: Expression, message: String = "", file: String = __FILE__, line: UInt = __LINE__) {
+    let parsed = parseTopLevelExpression(string)
+    assert(parsed.right, ==, expression, message: message, file: file, line: line)
+}

--- a/KaleidoscopeLangTests/KaleidoscopeLangTests.swift
+++ b/KaleidoscopeLangTests/KaleidoscopeLangTests.swift
@@ -10,6 +10,16 @@ import XCTest
 @testable import KaleidoscopeLang
 
 class KaleidoscopeLangTests: XCTestCase {
+    func testIdentifierTokenizer() {
+        assertMatched(identifierToken, "a".characters)
+        assertMatched(identifierToken, "some".characters)
+        assertMatched(identifierToken, "_some".characters)
+        assertMatched(identifierToken, "__some_".characters)
+        assertMatched(identifierToken, "__some".characters)
+        assertUnmatched(identifierToken, "2name".characters)
+        assertUnmatched(identifierToken, "2".characters)
+    }
+
     func testTokenizer() {
         assertStringToTokens("a+b", [.Identifier("a"), .Character("+"), .Identifier("b")])
 

--- a/KaleidoscopeLangTests/KaleidoscopeLangTests.swift
+++ b/KaleidoscopeLangTests/KaleidoscopeLangTests.swift
@@ -13,15 +13,42 @@ class KaleidoscopeLangTests: XCTestCase {
     func testTokenizer() {
         assertStringToTokens("a+b", [.Identifier("a"), .Character("+"), .Identifier("b")])
 
-        assertStringToTokens("def add(a b) a + b", [.Def, .Identifier("add"), .Character("("), .Identifier("a"), .Identifier("b"), .Character(")"), .Identifier("a"), .Character("+"), .Identifier("b")])
+        assertStringToTokens(
+            "def add(a b) a + b",
+            [
+                .Def, .Identifier("add"),
+                .Character("("), .Identifier("a"), .Identifier("b"), .Character(")"),
+                .Identifier("a"), .Character("+"), .Identifier("b")
+            ]
+        )
 
 
-        assertStringToTokens("def add(a b)\n\ta + b", [.Def, .Identifier("add"), .Character("("), .Identifier("a"), .Identifier("b"), .Character(")"), .Identifier("a"), .Character("+"), .Identifier("b")])
+        assertStringToTokens(
+            "def add(a b)\n\ta + b",
+            [
+                .Def, .Identifier("add"),
+                .Character("("), .Identifier("a"), .Identifier("b"), .Character(")"),
+                .Identifier("a"), .Character("+"), .Identifier("b")
+            ]
+        )
 
-        assertStringToTokens("extern atan2(a b)", [.Extern, .Identifier("atan2"), .Character("("), .Identifier("a"), .Identifier("b"), .Character(")")])
+        assertStringToTokens(
+            "extern atan2(a b)",
+            [
+                .Extern, .Identifier("atan2"),
+                .Character("("), .Identifier("a"), .Identifier("b"), .Character(")")
+            ]
+        )
 
 
-        assertStringToTokens("\textern atan2(y x);", [.Extern, .Identifier("atan2"), .Character("("), .Identifier("y"), .Identifier("x"), .Character(")"), .EndOfStatement])
+        assertStringToTokens(
+            "\textern atan2(y x);",
+            [
+                .Extern, .Identifier("atan2"),
+                .Character("("), .Identifier("y"), .Identifier("x"), .Character(")"),
+                .EndOfStatement
+            ]
+        )
     }
     
     func testParser() {

--- a/KaleidoscopeLangTests/KaleidoscopeLangTests.swift
+++ b/KaleidoscopeLangTests/KaleidoscopeLangTests.swift
@@ -7,72 +7,47 @@
 //
 
 import XCTest
-import Madness
 @testable import KaleidoscopeLang
-
-
-// These should be better. (e.g. Don’t force-unwrap the result & pull out common
-// assertion patterns). And the the coverage should be higher.
 
 class KaleidoscopeLangTests: XCTestCase {
     func testTokenizer() {
-        XCTAssert(
-            tokenizeTopLevelExpression("a+b").right!
-            ==
-            [.Identifier("a"), .Character("+"), .Identifier("b")]
-        )
-        
-        XCTAssert(
-            tokenizeTopLevelExpression("def add(a b) a + b").right!
-            ==
-            [.Def, .Identifier("add"), .Character("("), .Identifier("a"), .Identifier("b"), .Character(")"), .Identifier("a"), .Character("+"), .Identifier("b")]
-        )
+        assertStringToTokens("a+b", [.Identifier("a"), .Character("+"), .Identifier("b")])
 
-        XCTAssert(
-            tokenizeTopLevelExpression("def add(a b)\n\ta + b").right!
-            ==
-            [.Def, .Identifier("add"), .Character("("), .Identifier("a"), .Identifier("b"), .Character(")"), .Identifier("a"), .Character("+"), .Identifier("b")]
-        )
+        assertStringToTokens("def add(a b) a + b", [.Def, .Identifier("add"), .Character("("), .Identifier("a"), .Identifier("b"), .Character(")"), .Identifier("a"), .Character("+"), .Identifier("b")])
 
 
-        XCTAssert(
-            tokenizeTopLevelExpression("extern atan2(a b)").right!
-            ==
-            [.Extern, .Identifier("atan2"), .Character("("), .Identifier("a"), .Identifier("b"), .Character(")")]
-        )
+        assertStringToTokens("def add(a b)\n\ta + b", [.Def, .Identifier("add"), .Character("("), .Identifier("a"), .Identifier("b"), .Character(")"), .Identifier("a"), .Character("+"), .Identifier("b")])
 
-        XCTAssert(
-            tokenizeTopLevelExpression("\textern atan2(y x);").right!
-            ==
-            [.Extern, .Identifier("atan2"), .Character("("), .Identifier("y"), .Identifier("x"), .Character(")"), .EndOfStatement]
-        )
+        assertStringToTokens("extern atan2(a b)", [.Extern, .Identifier("atan2"), .Character("("), .Identifier("a"), .Identifier("b"), .Character(")")])
+
+
+        assertStringToTokens("\textern atan2(y x);", [.Extern, .Identifier("atan2"), .Character("("), .Identifier("y"), .Identifier("x"), .Character(")"), .EndOfStatement])
     }
     
     func testParser() {
-        let extern: [Token] = [.Extern, .Identifier("sin"), .Character("("), .Identifier("angle"), .Character(")"), .EndOfStatement]
-        XCTAssert(
-            parse(topLevelExpression, input: extern).right!
-            ==
+        assertTokensToExpression(
+            [.Extern, .Identifier("sin"), .Character("("), .Identifier("angle"), .Character(")"), .EndOfStatement],
             .Prototype(name: "sin", args: ["angle"])
         )
     }
     
     func testCombination() {
-        XCTAssert(
-            parseTopLevelExpression("extern sin(angle);").right!
-            ==
+        assertStringToExpression(
+            "extern sin(angle);",
             .Prototype(name: "sin", args: ["angle"])
         )
         
-        XCTAssert(
-            parseTopLevelExpression("a + b;").right!
-            ==
-            .BinaryOperator(code: "+", left: .Variable("a"), right: .Variable("b"))
+        assertStringToExpression(
+            "a + b;",
+            .BinaryOperator(
+                code: "+",
+                left: .Variable("a"),
+                right: .Variable("b")
+            )
         )
 
-        XCTAssert(
-            parseTopLevelExpression("a + sin(b) - c;").right!
-            ==
+        assertStringToExpression(
+            "a + sin(b) - c;",
             .BinaryOperator(
                 code: "+",
                 left: .Variable("a"),
@@ -87,10 +62,9 @@ class KaleidoscopeLangTests: XCTestCase {
             )
         )
         
-        XCTAssert(
-            parseTopLevelExpression("def add(a b) a + b;").right!
-            ==
-            Expression.Function(
+        assertStringToExpression(
+            "def add(a b) a + b;",
+            .Function(
                 prototype: .Prototype(
                     name: "add",
                     args: [ "a", "b" ]
@@ -105,46 +79,19 @@ class KaleidoscopeLangTests: XCTestCase {
     }
     
     func testComments() {
-        XCTAssert(
-            tokenizeTopLevelExpression("a + b; # this is addition\n").right!
-            ==
+        assertStringToTokens(
+            "a + b; # this is addition\n",
             [.Identifier("a"), .Character("+"), .Identifier("b"), .EndOfStatement]
         )
         
-        XCTAssert(
-            tokenizeTopLevelExpression("# this is only a comment\n").right!
-            ==
-            []
-        )
+        assertStringToTokens("# this is only a comment\n", [])
     }
     
     
     func testNumbers() {
-        XCTAssert(
-            parseTopLevelExpression("0;").right!
-            ==
-            .Number(0)
-        )
-        
-        print(parseTopLevelExpression("00.00;"))
-        print(parse(number, input: "00.00"))
-        
-        XCTAssert(
-            parseTopLevelExpression("00.00;").right!
-            ==
-            .Number(0)
-        )
-        
-        XCTAssert(
-            parseTopLevelExpression("10.0;").right!
-            ==
-            .Number(10)
-        )
-        
-        XCTAssert(
-            parseTopLevelExpression("10.01;").right!
-            ==
-            .Number(10.01)
-        )
+        assertStringToExpression("0;", .Number(0))
+        assertStringToExpression("00.00;", .Number(0))
+        assertStringToExpression("10.0;", .Number(10))
+        assertStringToExpression("10.01;", .Number(10.01))
     }
 }


### PR DESCRIPTION
- [x] Don’t force-unwrap results for comparison
- [X] Move parsing into assertion helpers
- [x] Regroup tests (`TokenizerTests`, `ParserTests`, `LanguageTests` (not sold on that last name… what to call tokenizer + parser?))
- [x] Split up test cases
- [ ] ~~Bonus: Find a better way to represent an AST in code, it’s unwieldy as is~~ #4
