### PR TITLE
Expression enum → protocols + structs

### DIFF
--- a/KaleidoscopeLang/Expression.swift
+++ b/KaleidoscopeLang/Expression.swift
@@ -6,69 +6,108 @@
 //  Copyright © 2015 Ben Cochran. All rights reserved.
 //
 
-public indirect enum Expression {
-    case Number(Double)
-    case Variable(String)
-    case BinaryOperator(code: Character, left: Expression, right: Expression)
-    case Call(callee: String, args: [Expression])
-    case Prototype(name: String, args: [String])
-    case Function(prototype: Expression, body: Expression)
-}
+// MARK: Types
 
-extension Expression : Equatable {}
-public func == (lhs: Expression, rhs: Expression) -> Bool {
-    switch (lhs, rhs) {
-    case let (.Number(l1), .Number(r1)): return l1 == r1
-    case let (.Variable(l1), .Variable(r1)): return l1 == r1
-    case let (.BinaryOperator(l1, l2, l3), .BinaryOperator(r1, r2, r3)): return l1 == r1 && l2 == r2 && l3 == r3
-    case let (.Call(l1, l2), .Call(r1, r2)): return l1 == r1 && l2 == r2
-    case let (.Prototype(l1, l2), .Prototype(r1, r2)): return l1 == r1 && l2 == r2
-    case let (.Function(l1, l2), .Function(r1, r2)): return l1 == r1 && l2 == r2
-    default: return false
+public protocol Expression {
+    // The ol’ non-self-requirement protocol dance
+    func equals(other: Expression) -> Bool
+}
+public protocol ValueExpression : Expression { }
+public protocol TopLevelExpression : Expression { }
+
+extension Expression where Self : Equatable {
+    public func equals(other: Expression) -> Bool {
+        if let other = other as? Self { return self == other }
+        return false
     }
 }
-
-internal extension Expression {
-    internal var number: Double? {
-        switch self {
-        case let .Number(number): return number
-        default: return nil
-        }
-    }
-    
-    internal var variable: String? {
-        switch self {
-        case let .Variable(variable): return variable
-        default: return nil
-        }
-    }
-    
-    internal var binaryOperator: (code: Character, left: Expression, right: Expression)? {
-        switch self {
-        case let .BinaryOperator(code, left, right): return (code, left, right)
-        default: return nil
-        }
-    }
-    
-    internal var call: (callee: String, args: [Expression])? {
-        switch self {
-        case let .Call(callee, args): return (callee, args)
-        default: return nil
-        }
-    }
-    
-    internal var prototype: (name: String, args: [String])? {
-        switch self {
-        case let .Prototype(name, args): return (name, args)
-        default: return nil
-        }
-    }
-    
-    internal var function: (prototype: Expression, body: Expression)? {
-        switch self {
-        case let .Function(prototype, body): return (prototype, body)
-        default: return nil
-        }
-    }
+public func == (left: Expression, right: Expression) -> Bool {
+    return left.equals(right)
 }
 
+// MARK: Number
+
+public struct NumberExpression : ValueExpression, Equatable {
+    public let value: Double
+    public init(_ value: Double) {
+        self.value = value
+    }
+}
+public func == (left: NumberExpression, right: NumberExpression) -> Bool {
+    return left.value == right.value
+}
+
+// MARK: Variable
+
+public struct VariableExpression : ValueExpression, Equatable {
+    public let name: String
+    public init(_ name: String) {
+        self.name = name
+    }
+}
+public func == (left: VariableExpression, right: VariableExpression) -> Bool {
+    return left.name == right.name
+}
+
+// MARK: BinaryOperator
+
+public struct BinaryOperatorExpression : ValueExpression, Equatable {
+    public let code: Character
+    public let left: ValueExpression
+    public let right: ValueExpression
+    public init(code: Character, left: ValueExpression, right: ValueExpression) {
+        self.code = code
+        self.left = left
+        self.right = right
+    }
+}
+public func == (left: BinaryOperatorExpression, right: BinaryOperatorExpression) -> Bool {
+    return left.code == right.code
+        && left.left.equals(right.left)
+        && left.right.equals(right.right)
+}
+
+// MARK: Call
+
+public struct CallExpression : ValueExpression, Equatable {
+    public let callee: String
+    public let args: [ValueExpression]
+    public init(callee: String, args: [ValueExpression]) {
+        self.callee = callee
+        self.args = args
+    }
+}
+public func == (left: CallExpression, right: CallExpression) -> Bool {
+    return left.callee == right.callee
+        && zip(left.args, right.args).map({ $0.equals($1) }).reduce(true, combine: { $0 && $1 })
+}
+
+// MARK: Prototype
+
+public struct PrototypeExpression : TopLevelExpression, Equatable {
+    public let name: String
+    public let args: [String]
+    public init(name: String, args: [String]) {
+        self.name = name
+        self.args = args
+    }
+}
+public func == (left: PrototypeExpression, right: PrototypeExpression) -> Bool {
+    return left.name == right.name
+        && left.args == right.args
+}
+
+// MARK: Function
+
+public struct FunctionExpression : TopLevelExpression, Equatable {
+    public let prototype: PrototypeExpression
+    public let body: ValueExpression
+    public init(prototype: PrototypeExpression, body: ValueExpression) {
+        self.prototype = prototype
+        self.body = body
+    }
+}
+public func == (left: FunctionExpression, right: FunctionExpression) -> Bool {
+    return left.prototype == right.prototype
+        && left.body.equals(right.body)
+}

--- a/KaleidoscopeLang/Parser.swift
+++ b/KaleidoscopeLang/Parser.swift
@@ -10,30 +10,32 @@ import Madness
 import Prelude
 import Either
 
-typealias ExpressionParser = Parser<[Token], Expression>.Function
+internal typealias ValueExpressionParser = Parser<[Token], ValueExpression>.Function
+internal typealias TopLevelExpressionParser = Parser<[Token], TopLevelExpression>.Function
+internal typealias ExpressionParser = Parser<[Token], Expression>.Function
 
 // MARK: Token unwrappers
 
 private let identifier: Parser<[Token], String>.Function = attempt { $0.identifier }
 private let double: Parser<[Token], Double>.Function = attempt { $0.number }
 
-// MARK: Grammar
+// MARK: Value expressions
 
-private let expression: ExpressionParser = fix { expression in
+private let valueExpression: ValueExpressionParser = fix { valueExpression in
     /// variable ::= Identifier
-    let variable: ExpressionParser = Expression.Variable <^> identifier
+    let variable: ValueExpressionParser = VariableExpression.init <^> identifier
     
     /// number ::= Number
-    let number: ExpressionParser = Expression.Number <^> double
+    let number: ValueExpressionParser = NumberExpression.init <^> double
     
-    /// parenExpression ::= "(" expression ")"
-    let parenExpression = %(.Character("(")) *> expression <* %(.Character(")"))
+    /// parenExpression ::= "(" valueExpression ")"
+    let parenExpression = %(.Character("(")) *> valueExpression <* %(.Character(")"))
     
-    /// callargs ::= "(" expression* ")"
-    let callargs = %(.Character("(")) *> many(expression) <* %(.Character(")"))
+    /// callargs ::= "(" valueExpression* ")"
+    let callargs = %(.Character("(")) *> many(valueExpression) <* %(.Character(")"))
     
     /// call ::= Identifier callargs
-    let call = Expression.Call <^> ( lift(pair) <*> identifier <*> callargs )
+    let call: ValueExpressionParser = CallExpression.init <^> ( lift(pair) <*> identifier <*> callargs )
     
     /// primary
     ///     ::= call
@@ -59,53 +61,87 @@ private let expression: ExpressionParser = fix { expression in
     
     /// infix ::= primary infixRight*
     let repackedInfix = map(id, ArraySlice.init) <^> ( lift(pair) <*> primary <*> many(infixRight) )
-    let infix: ExpressionParser = collapsePackedInfix <^> repackedInfix
+    let infix: ValueExpressionParser = collapsePackedInfix <^> repackedInfix
     
-    /// expression
+    /// valueExpression
     ///     ::= infix
     ///     ::= primary
     return infix <|> primary
 }
 
+// MARK: Top-level expressions
+
 /// prototypeArgs ::= "(" Identifier* ")"
 private let prototypeArgs = %(.Character("(")) *> many(identifier) <* %(.Character(")"))
 
 /// prototype ::= Identifier prototypeArgs
-private let prototype = Expression.Prototype <^> ( lift(pair) <*> identifier <*> prototypeArgs )
+private let prototype = PrototypeExpression.init <^> ( lift(pair) <*> identifier <*> prototypeArgs )
 
 /// definition ::= "def" prototype expression
-private let definition: ExpressionParser = Expression.Function <^> ( %(Token.Def) *> lift(pair) <*> prototype <*> expression )
+private let definition: TopLevelExpressionParser = FunctionExpression.init <^> ( %(Token.Def) *> lift(pair) <*> prototype <*> valueExpression )
 
 /// external ::= "extern" prototype
-private let external = %(Token.Extern) *> prototype
+private let external: TopLevelExpressionParser = id <^> ( %(Token.Extern) *> prototype )
 
 /// top
 ///     ::= definition
 ///     ::= external
-///     ::= expression
-private let top = definition <|> external <|> expression
+private let top = definition <|> external
 
 /// topLevelExpression ::= top EndOfStatement
 internal let topLevelExpression = top <* %(.EndOfStatement)
 
+/// expression
+///     ::= topLevelExpression
+///     ::= valueExpression
+internal let expression = topLevelExpression <|> valueExpression
+
+
 // MARK: Public
 
-public func parse(tokens: [Token]) -> Either<Error, Expression> {
+/// Parse a series of tokens into a value expression
+public func parseValueExpression(tokens: [Token]) -> Either<Error, ValueExpression> {
+    return parse(valueExpression, input: tokens).mapLeft(Error.treeError(tokens))
+}
+/// Lex and parse a string into a value expression
+public func parseValueExpression(string: String) -> Either<Error, ValueExpression> {
+    return lex(string) >>- parseValueExpression
+}
+
+/// Parse a series of tokens into a top-level expression
+public func parseTopLevelExpression(tokens: [Token]) -> Either<Error, TopLevelExpression> {
     return parse(topLevelExpression, input: tokens).mapLeft(Error.treeError(tokens))
 }
 
+/// Lex and parse a string into a top-level expression
+public func parseTopLevelExpression(string: String) -> Either<Error, TopLevelExpression> {
+    return lex(string) >>- parseTopLevelExpression
+}
+
+/// Parse a series of tokens into a value or top-level expression
+public func parse(tokens: [Token]) -> Either<Error, Expression> {
+    return parse(expression, input: tokens).mapLeft(Error.treeError(tokens)).map(collapseExpression)
+}
+
+/// Lex and parse a string into a value or top-level expression
 public func parse(string: String) -> Either<Error, Expression> {
     return lex(string) >>- parse
 }
 
+// MARK: Private
+
+private func collapseExpression(expression: Either<TopLevelExpression, ValueExpression>) -> Expression {
+    return expression.either(ifLeft: id, ifRight: id)
+}
+
 // MARK: Infix Helpers
 
-private func collapsePackedInfix(binop: (Expression, ArraySlice<(Token, Expression)>)) -> Expression {
+private func collapsePackedInfix(binop: (ValueExpression, ArraySlice<(Token, ValueExpression)>)) -> ValueExpression {
     // Recursion base
     guard let rightHalf = binop.1.first else { return binop.0 }
     
     let code = rightHalf.0.character!
     let rest = (rightHalf.1, binop.1.dropFirst())
     let left = binop.0
-    return .BinaryOperator(code: code, left: left, right: collapsePackedInfix(rest))
+    return BinaryOperatorExpression(code: code, left: left, right: collapsePackedInfix(rest))
 }

--- a/KaleidoscopeLangTests/Assertions.swift
+++ b/KaleidoscopeLangTests/Assertions.swift
@@ -50,12 +50,26 @@ func assertStringToTokens(string: String, _ tokens: [Token], message: String = "
     assert(parsed.right, ==, tokens, message: message, file: file, line: line)
 }
 
-func assertTokensToExpression(tokens: [Token], _ expression: Expression, message: String = "", file: String = __FILE__, line: UInt = __LINE__) {
-    let parsed = parse(tokens)
+func assertTokensToTopLevelExpression(tokens: [Token], _ expression: TopLevelExpression, message: String = "", file: String = __FILE__, line: UInt = __LINE__) {
+    let parsed = parseTopLevelExpression(tokens)
     assert(parsed.right, ==, expression, message: message, file: file, line: line)
 }
 
-func assertStringToExpression(string: String, _ expression: Expression, message: String = "", file: String = __FILE__, line: UInt = __LINE__) {
-    let parsed = parse(string)
+func assertTokensToValueExpression(tokens: [Token], _ expression: ValueExpression, message: String = "", file: String = __FILE__, line: UInt = __LINE__) {
+    let parsed = parseValueExpression(tokens)
     assert(parsed.right, ==, expression, message: message, file: file, line: line)
+}
+
+func assertStringToTopLevelExpression(string: String, _ expression: TopLevelExpression, message: String = "", file: String = __FILE__, line: UInt = __LINE__) {
+    let parsed = parseTopLevelExpression(string)
+    assert(parsed.right, ==, expression, message: message, file: file, line: line)
+}
+
+func assertStringToValueExpression(string: String, _ expression: ValueExpression, message: String = "", file: String = __FILE__, line: UInt = __LINE__) {
+    let parsed = parseValueExpression(string)
+    assert(parsed.right, ==, expression, message: message, file: file, line: line)
+}
+
+func == (left: Expression, right: Expression) -> Bool {
+    return left.equals(right)
 }

--- a/KaleidoscopeLangTests/KaleidoscopeLangTests.swift
+++ b/KaleidoscopeLangTests/KaleidoscopeLangTests.swift
@@ -66,62 +66,62 @@ class LexerTests: XCTestCase {
 
 class ParserTests: XCTestCase {
     func testParser() {
-        assertTokensToExpression(
+        assertTokensToTopLevelExpression(
             [.Extern, .Identifier("sin"), .Character("("), .Identifier("angle"), .Character(")"), .EndOfStatement],
-            .Prototype(name: "sin", args: ["angle"])
+            PrototypeExpression(name: "sin", args: ["angle"])
         )
     }
 }
 
 class CombinedTests: XCTestCase {
     func testExtern() {
-        assertStringToExpression(
+        assertStringToTopLevelExpression(
             "extern sin(angle);",
-            .Prototype(name: "sin", args: ["angle"])
+            PrototypeExpression(name: "sin", args: ["angle"])
         )
     }
     
     func testBinaryOperator() {
-        assertStringToExpression(
-            "a + b;",
-            .BinaryOperator(
+        assertStringToValueExpression(
+            "a + b",
+            BinaryOperatorExpression(
                 code: "+",
-                left: .Variable("a"),
-                right: .Variable("b")
+                left: VariableExpression("a"),
+                right: VariableExpression("b")
             )
         )
     }
     
     func testComplexBinaryOperator() {
-        assertStringToExpression(
-            "a + sin(b) - c;",
-            .BinaryOperator(
+        assertStringToValueExpression(
+            "a + sin(b) - c",
+            BinaryOperatorExpression(
                 code: "+",
-                left: .Variable("a"),
-                right: .BinaryOperator(
+                left: VariableExpression("a"),
+                right: BinaryOperatorExpression(
                     code: "-",
-                    left: .Call(
+                    left: CallExpression(
                         callee: "sin",
-                        args: [ .Variable("b") ]
+                        args: [ VariableExpression("b") ]
                     ),
-                    right: .Variable("c")
+                    right: VariableExpression("c")
                 )
             )
         )
     }
     
     func testDefinition() {
-        assertStringToExpression(
+        assertStringToTopLevelExpression(
             "def add(a b) a + b;",
-            .Function(
-                prototype: .Prototype(
+            FunctionExpression(
+                prototype: PrototypeExpression(
                     name: "add",
                     args: [ "a", "b" ]
                 ),
-                body: .BinaryOperator(
+                body: BinaryOperatorExpression(
                     code: "+",
-                    left: .Variable("a"),
-                    right: .Variable("b")
+                    left: VariableExpression("a"),
+                    right: VariableExpression("b")
                 )
             )
         )
@@ -137,9 +137,9 @@ class CombinedTests: XCTestCase {
     }
     
     func testTopLevelNumbers() {
-        assertStringToExpression("0;", .Number(0))
-        assertStringToExpression("00.00;", .Number(0))
-        assertStringToExpression("10.0;", .Number(10))
-        assertStringToExpression("10.01;", .Number(10.01))
+        assertStringToValueExpression("0", NumberExpression(0))
+        assertStringToValueExpression("00.00", NumberExpression(0))
+        assertStringToValueExpression("10.0", NumberExpression(10))
+        assertStringToValueExpression("10.01", NumberExpression(10.01))
     }
 }


### PR DESCRIPTION
This has a few benefits:
1. Expressions can constrain certain members to be a specific type of expression. For example, `FunctionExpression`’s `protocol` can now be statically guaranteed to be a `ProtocolExpression`.
2. We can differentiate between value expressions and top-level expressions. This can be useful, for example, in a REPL where value expressions are valid at the top level vs. file compilation where only true top-level expressions are.

This adds some grossness with equality checking, however. Since we want to be able to have `[Expression]` we can’t make that protocol have a self-requirement (by conforming to `Equatable`). So we have to do the fun dance of adding `equals(other: Expression) -> Bool` to the `Expression` protocol (see [WWDC 2015 Session 408](https://developer.apple.com/videos/play/wwdc2015-408/)[<sup>1</sup>](#footnote-1)).

---

<sup id="footnote-1">1.</sup> Sorry for making you sit through the Crusty bit.
